### PR TITLE
Feat/always send values on change

### DIFF
--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react'
+import propTypes from 'prop-types'
 import { Field, Checkbox as CoreCheckbox, Help } from '@dhis2/ui-core'
 
 import { FieldAdapter, adapterComponentProps } from './FieldAdapter.js'
@@ -9,6 +10,7 @@ const Checkbox = ({
     disabled,
     name,
     value,
+    checkedValue,
     onChange,
     error,
     warning,
@@ -21,7 +23,7 @@ const Checkbox = ({
             required={required}
             name={name}
             disabled={disabled}
-            value={value}
+            value={checkedValue}
             label={label}
             checked={!!value}
             onChange={onChange}
@@ -36,10 +38,21 @@ const Checkbox = ({
 
 Checkbox.propTypes = {
     ...adapterComponentProps,
+    checkedValue: propTypes.string,
+}
+
+// If the input has a value (checkedValue prop) the form value is: checkedValue || ''
+// Otherwise the form-value is: true || false
+const getValue = ({ checked, value }) => {
+    if (value) {
+        return checked ? value : ''
+    } else {
+        return !!checked
+    }
 }
 
 const useCheckboxOnChange = onChange =>
-    useCallback(event => onChange(!!event.target.checked), [onChange])
+    useCallback(event => onChange(getValue(event.target)), [onChange])
 
 const CheckboxAdapter = props => (
     <FieldAdapter

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -3,50 +3,50 @@ import { Field, Checkbox as CoreCheckbox, Help } from '@dhis2/ui-core'
 
 import { FieldAdapter, adapterComponentProps } from './FieldAdapter.js'
 
-const useCheckboxOnChange = onChange =>
-    useCallback(event => onChange(!!event.target.checked), [onChange])
-
 const Checkbox = ({
     label,
     required,
     disabled,
     name,
     value,
-    onChange: adapterOnChange,
+    onChange,
     error,
     warning,
     valid,
     helpText,
     errorText,
-}) => {
-    const onChange = useCheckboxOnChange(adapterOnChange)
-
-    return (
-        <Field>
-            <CoreCheckbox
-                required={required}
-                name={name}
-                disabled={disabled}
-                value={value}
-                label={label}
-                checked={!!value}
-                onChange={onChange}
-                error={error}
-                warning={warning}
-                valid={valid}
-            />
-            {helpText && <Help>{helpText}</Help>}
-            {error && errorText && <Help error>{errorText}</Help>}
-        </Field>
-    )
-}
+}) => (
+    <Field>
+        <CoreCheckbox
+            required={required}
+            name={name}
+            disabled={disabled}
+            value={value}
+            label={label}
+            checked={!!value}
+            onChange={onChange}
+            error={error}
+            warning={warning}
+            valid={valid}
+        />
+        {helpText && <Help>{helpText}</Help>}
+        {error && errorText && <Help error>{errorText}</Help>}
+    </Field>
+)
 
 Checkbox.propTypes = {
     ...adapterComponentProps,
 }
 
+const useCheckboxOnChange = onChange =>
+    useCallback(event => onChange(!!event.target.checked), [onChange])
+
 const CheckboxAdapter = props => (
-    <FieldAdapter {...props} component={Checkbox} />
+    <FieldAdapter
+        {...props}
+        component={Checkbox}
+        useOnChange={useCheckboxOnChange}
+    />
 )
 
 export { Checkbox, CheckboxAdapter }

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -1,0 +1,52 @@
+import React, { useCallback } from 'react'
+import { Field, Checkbox as CoreCheckbox, Help } from '@dhis2/ui-core'
+
+import { FieldAdapter, adapterComponentProps } from './FieldAdapter.js'
+
+const useCheckboxOnChange = onChange =>
+    useCallback(event => onChange(!!event.target.checked), [onChange])
+
+const Checkbox = ({
+    label,
+    required,
+    disabled,
+    name,
+    value,
+    onChange: adapterOnChange,
+    error,
+    warning,
+    valid,
+    helpText,
+    errorText,
+}) => {
+    const onChange = useCheckboxOnChange(adapterOnChange)
+
+    return (
+        <Field>
+            <CoreCheckbox
+                required={required}
+                name={name}
+                disabled={disabled}
+                value={value}
+                label={label}
+                checked={!!value}
+                onChange={onChange}
+                error={error}
+                warning={warning}
+                valid={valid}
+            />
+            {helpText && <Help>{helpText}</Help>}
+            {error && errorText && <Help error>{errorText}</Help>}
+        </Field>
+    )
+}
+
+Checkbox.propTypes = {
+    ...adapterComponentProps,
+}
+
+const CheckboxAdapter = props => (
+    <FieldAdapter {...props} component={Checkbox} />
+)
+
+export { Checkbox, CheckboxAdapter }

--- a/src/components/FieldAdapter.js
+++ b/src/components/FieldAdapter.js
@@ -11,8 +11,14 @@ const useAdapterOnChange = onChange =>
         [onChange]
     )
 
-const FieldAdapter = ({ input, meta, component: Component, ...ownProps }) => {
-    const onChange = useAdapterOnChange(input.onChange)
+const FieldAdapter = ({
+    input,
+    meta,
+    component: Component,
+    useOnChange,
+    ...ownProps
+}) => {
+    const onChange = useOnChange(input.onChange)
 
     return (
         <Component
@@ -38,6 +44,11 @@ FieldAdapter.propTypes = {
     ...fieldRenderProps,
     component: propTypes.oneOfType([propTypes.func, propTypes.object])
         .isRequired,
+    useOnChange: propTypes.func,
+}
+
+FieldAdapter.defaultProps = {
+    useOnChange: useAdapterOnChange,
 }
 
 const adapterComponentProps = {

--- a/src/components/FieldAdapter.js
+++ b/src/components/FieldAdapter.js
@@ -1,23 +1,38 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import propTypes from 'prop-types'
 import { fieldRenderProps, fieldInputProps, fieldMetaProps } from './Field'
 
-const FieldAdapter = ({ input, meta, component: Component, ...ownProps }) => (
-    <Component
-        {...input}
-        {...meta}
-        {...ownProps}
-        error={ownProps.error || (meta.touched && meta.invalid)}
-        valid={
-            ownProps.valid ||
-            (ownProps.showValidStatus && meta.touched && meta.valid)
-        }
-        loading={
-            ownProps.loading || (ownProps.showLoadingStatus && meta.validating)
-        }
-        errorText={ownProps.errorText || meta.error || ''}
-    />
-)
+const useAdapterOnChange = onChange =>
+    useCallback(
+        potentialEvent =>
+            potentialEvent && potentialEvent.target
+                ? onChange(potentialEvent.target.value)
+                : onChange(potentialEvent),
+        [onChange]
+    )
+
+const FieldAdapter = ({ input, meta, component: Component, ...ownProps }) => {
+    const onChange = useAdapterOnChange(input.onChange)
+
+    return (
+        <Component
+            {...input}
+            {...meta}
+            {...ownProps}
+            error={ownProps.error || (meta.touched && meta.invalid)}
+            valid={
+                ownProps.valid ||
+                (ownProps.showValidStatus && meta.touched && meta.valid)
+            }
+            loading={
+                ownProps.loading ||
+                (ownProps.showLoadingStatus && meta.validating)
+            }
+            errorText={ownProps.errorText || meta.error || ''}
+            onChange={onChange}
+        />
+    )
+}
 
 FieldAdapter.propTypes = {
     ...fieldRenderProps,

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 // Components
+export { Checkbox, CheckboxAdapter } from './components/Checkbox.js'
 export { Form } from './components/Form.js'
 export { Field } from './components/Field.js'
 export { FileInput, FileInputAdapter } from './components/FileInput.js'

--- a/stories/Checkbox.stories.js
+++ b/stories/Checkbox.stories.js
@@ -1,11 +1,76 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, CheckboxAdapter } from '../src'
+import { Field, CheckboxAdapter, required } from '../src'
 import { formDecorator } from './helpers/formDecorator'
 
 storiesOf('Checkbox', module)
     .addDecorator(formDecorator)
     .add('Default', () => (
         <Field component={CheckboxAdapter} name="agree" label="Do you agree?" />
+    ))
+    .add('Required', () => (
+        <Field
+            name="agree"
+            component={CheckboxAdapter}
+            required
+            validate={required}
+            label="Do you agree?"
+        />
+    ))
+    .add('Disabled', () => (
+        <Field
+            name="agree"
+            component={CheckboxAdapter}
+            disabled
+            label="Do you agree?"
+        />
+    ))
+    .add('Help text', () => (
+        <Field
+            name="agree"
+            component={CheckboxAdapter}
+            label="Do you agree?"
+            helpText="Click to agree"
+        />
+    ))
+    .add('Statuses', () => (
+        <>
+            <Field
+                name="valid"
+                component={CheckboxAdapter}
+                label="Valid"
+                valid
+            />
+            <Field
+                name="warning"
+                component={CheckboxAdapter}
+                label="Warning"
+                warning
+            />
+            <Field
+                name="error"
+                component={CheckboxAdapter}
+                label="Error"
+                error
+                errorText="Oops"
+            />
+        </>
+    ))
+    .add('Value when checked', () => (
+        <>
+            <Field
+                name="bool"
+                component={CheckboxAdapter}
+                label="I produce boolean form values"
+                helpText="Click submit and check the console"
+            />
+            <Field
+                name="string"
+                component={CheckboxAdapter}
+                label="I produce string form values"
+                checkedValue="value_when_checked"
+                helpText="Click submit and check the console"
+            />
+        </>
     ))

--- a/stories/Checkbox.stories.js
+++ b/stories/Checkbox.stories.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import { Field, CheckboxAdapter } from '../src'
+import { formDecorator } from './helpers/formDecorator'
+
+storiesOf('Checkbox', module)
+    .addDecorator(formDecorator)
+    .add('Default', () => (
+        <Field component={CheckboxAdapter} name="agree" label="Do you agree?" />
+    ))

--- a/stories/FileInput.stories.js
+++ b/stories/FileInput.stories.js
@@ -9,7 +9,6 @@ storiesOf('FileInput', module)
     .add('Default', () => (
         <Field
             component={FileInputAdapter}
-            type="file"
             name="upload"
             label="This is a file upload"
             multifile
@@ -18,7 +17,6 @@ storiesOf('FileInput', module)
     .add('Required', () => (
         <Field
             component={FileInputAdapter}
-            type="file"
             name="upload"
             label="This is a file upload"
             required

--- a/stories/RadioGroup.stories.js
+++ b/stories/RadioGroup.stories.js
@@ -18,7 +18,6 @@ storiesOf('RadioGroup', module)
             label="Choose something"
             component={RadioGroupAdapter}
             options={options}
-            type="select"
         />
     ))
     .add('Required', () => (
@@ -29,7 +28,6 @@ storiesOf('RadioGroup', module)
             validate={required}
             required
             options={options}
-            type="select"
             inline={false}
         />
     ))


### PR DESCRIPTION
I've discussed this with @Mohammer5 a bit already and will try to summarise the situation below:

### Context
- Our ui-core components typically attach an onChange handler directly to a native element, so an Event instance is passed to onChange (I think this is good).
- The `FieldRenderProps` made available by the `Field` component from React Final Form (RFF) also include an onChange function. When this is called with an event, [some magic](https://github.com/final-form/react-final-form/blob/master/src/getValue.js) happens. However, when it is called with something that isn't an event, [all this magic is skipped](https://github.com/final-form/react-final-form/blob/master/src/useField.js#L140-L159) and the state is just updated with the values as they come in.
- Sometimes this magical behaviour can be useful, for example when building a checkbox, which can be made to work without hardly any code. **However**, this magical behaviour only seems to work properly if the correct `type` property is set on a `Field` as well.
- This `type` prop is hardly documented, and it seems (i.e. see here: https://github.com/final-form/react-final-form/issues/392#issuecomment-498244495) that this `type` property is only meant to make the native elements work correctly (i.e. when you pass a string to the `component` prop). So it sort of feels like we are misusing it a bit here.
- Also, at other times, the `type` can be a bit confusing. When I built the RadioGroup and I didn't have a type declared on the Field in the story, I would get a warning about having to add `type="radio"`. But when I did this, the input stopped working as expected. In the end I got it to work with `type="select"`. I suppose it makes sense for a group of radios, but it sure is counter-intuitive...

### Chosen approach in this PR
I think that none of the `Adapter` components in `ui-forms` should call the `Field`s `onChange` prop with an event, but always with a value. This way we get a few major advantages:
- We don't have to add different `type`s to different `Field`s depending on the component they are using. This will make the lib much easier and less frustrating to use.
- The behaviour will always be exactly be exactly the same for any input component. 100% predictability.

One minor downside is that in a very limited number of cases we will have to do a little bit more work. But at least we are in full control of the values that end up in the form this way...

### Implementation
- The `FieldAdapter` now has its own `onChange` handler. When called with an event, it will pull the `value` from it and call the `Field`s `onChange` with that.
- I've implemented this as a prop with a defaultValue, so this behaviour can be overridden when required.
- I've introduced a `Checkbox` component, because a lot of the things above were happening in the context of this component:
    - It demonstrates that this component now works without having to declare a `type` on the `Field`
    - It demonstrates how the onChange behaviour for a component can be customized via the `useOnChange` prop in the `FieldAdapter`
- Stories were added for this new component
- All `type` declarations have been removed from the `Field`s in the stories
- And last but not least: The way I have implemented this now, which is also how I would like to keep working wherever possible, makes this distinction:
    - The `Checkbox` returns an event on change.
    - The `CheckboxAdapter` (i.e. RFF Field compatible) returns values.