### PR TITLE
refactor: updated version of the file input after ui-core changes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,4 +3,7 @@ const { config } = require('@dhis2/cli-style')
 module.exports = {
     parser: 'babel-eslint',
     extends: ['eslint:recommended', 'plugin:react/recommended', config.eslint],
+    env: {
+        es6: true,
+    },
 }

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-09-04T13:26:27.402Z\n"
-"PO-Revision-Date: 2019-09-04T13:26:27.402Z\n"
+"POT-Creation-Date: 2019-10-02T13:53:17.458Z\n"
+"PO-Revision-Date: 2019-10-02T13:53:17.458Z\n"
 
 msgid "Upload file"
 msgstr ""
@@ -14,10 +14,10 @@ msgstr ""
 msgid "Upload files"
 msgstr ""
 
-msgid "No file(s) selected yet"
+msgid "Remove"
 msgstr ""
 
-msgid "Remove"
+msgid "No file(s) selected yet"
 msgstr ""
 
 msgid "Required"

--- a/src/components/FieldAdapter.js
+++ b/src/components/FieldAdapter.js
@@ -34,7 +34,9 @@ const FieldAdapter = ({
                 ownProps.loading ||
                 (ownProps.showLoadingStatus && meta.validating)
             }
-            errorText={ownProps.errorText || meta.error || ''}
+            validationText={
+                ownProps.errorText || (meta.touched && meta.error) || ''
+            }
             onChange={onChange}
         />
     )
@@ -58,7 +60,7 @@ const adapterComponentProps = {
     error: propTypes.bool,
     valid: propTypes.bool,
     loading: propTypes.bool,
-    errorText: propTypes.string,
+    validationText: propTypes.string,
     // other commmon props used by input components
     className: propTypes.string,
     label: propTypes.string,
@@ -66,6 +68,7 @@ const adapterComponentProps = {
     disabled: propTypes.bool,
     warning: propTypes.bool,
     helpText: propTypes.string,
+    tabIndex: propTypes.string,
 }
 
 export { FieldAdapter, adapterComponentProps }

--- a/src/components/FileInput.js
+++ b/src/components/FileInput.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react'
+import React, { Component } from 'react'
 import propTypes from 'prop-types'
 import i18n from '@dhis2/d2-i18n'
 import {
@@ -10,7 +10,7 @@ import { FieldAdapter, adapterComponentProps } from './FieldAdapter.js'
 const btnLabel = i18n.t('Upload file')
 const btnLabelMulti = i18n.t('Upload files')
 
-class FileInput extends PureComponent {
+class FileInputComponent extends Component {
     onFileInputChange = fileList => {
         const { multifile, onChange } = this.props
         // A JavaScript FileList instance is read-only, so we cannot add files to it
@@ -24,12 +24,11 @@ class FileInput extends PureComponent {
     // This deduplicates the file array based on file name
     // and keeps the most recent version of the found duplicate
     dedupeAndConcat(fileList) {
-        const reversedNewFileArray = [...fileList].reverse()
-        return [...reversedNewFileArray, ...this.props.value].reduce(
+        return [...this.props.value, ...fileList].reduceRight(
             (acc, file) => {
                 if (!acc.unique.has(file.name)) {
                     acc.unique.add(file.name)
-                    acc.files.push(file)
+                    acc.files.unshift(file)
                 }
                 return acc
             },
@@ -41,7 +40,7 @@ class FileInput extends PureComponent {
         const { value, onChange } = this.props
         const files = value.filter(file => file !== fileToDelete)
 
-        onChange(files.length > 0 ? files : null)
+        onChange(files.length > 0 ? files : '')
     }
 
     render() {
@@ -88,7 +87,7 @@ class FileInput extends PureComponent {
                 tabIndex={tabIndex}
                 placeholder={placeholder}
             >
-                {value &&
+                {Array.isArray(value) &&
                     value.map(file => (
                         <FileListItem
                             key={file.name}
@@ -102,11 +101,11 @@ class FileInput extends PureComponent {
     }
 }
 
-FileInput.defaultProps = {
+FileInputComponent.defaultProps = {
     placeholder: i18n.t('No file(s) selected yet'),
 }
 
-FileInput.propTypes = {
+FileInputComponent.propTypes = {
     ...adapterComponentProps,
     accept: propTypes.string,
     buttonLabel: propTypes.string,
@@ -120,8 +119,8 @@ FileInput.propTypes = {
     placeholder: propTypes.string,
 }
 
-const FileInputAdapter = props => (
-    <FieldAdapter {...props} component={FileInput} />
+const FileInput = props => (
+    <FieldAdapter {...props} component={FileInputComponent} />
 )
 
-export { FileInputAdapter, FileInput }
+export { FileInput }

--- a/src/components/FileInput.js
+++ b/src/components/FileInput.js
@@ -1,13 +1,14 @@
 import React, { PureComponent } from 'react'
 import propTypes from 'prop-types'
 import i18n from '@dhis2/d2-i18n'
-import { FileInput as UiCoreFileInput, Help, Field } from '@dhis2/ui-core'
+import {
+    FileInputField as UiCoreFileInputField,
+    FileListItem,
+} from '@dhis2/ui-core'
 import { FieldAdapter, adapterComponentProps } from './FieldAdapter.js'
 
-const messages = {
-    uploadFile: i18n.t('Upload file'),
-    uploadFiles: i18n.t('Upload files'),
-}
+const btnLabel = i18n.t('Upload file')
+const btnLabelMulti = i18n.t('Upload files')
 
 class FileInput extends PureComponent {
     onFileInputChange = fileList => {
@@ -43,80 +44,66 @@ class FileInput extends PureComponent {
         onChange(files.length > 0 ? files : null)
     }
 
-    getButtonLabel() {
-        return this.props.buttonLabel || this.props.multifile
-            ? messages.uploadFiles
-            : messages.uploadFile
-    }
-
-    getDisabled() {
-        return (
-            this.props.disabled ||
-            (!this.props.multifile && this.props.value.length >= 1)
-        )
-    }
-
     render() {
         const {
             className,
             label,
+            buttonLabel,
             required,
+            disabled,
             error,
             warning,
             valid,
             helpText,
-            errorText,
             multifile,
             small,
             large,
             accept,
             value,
+            validationText,
+            tabIndex,
+            placeholder,
         } = this.props
 
         return (
-            <Field className={className}>
-                <UiCoreFileInput
-                    onChange={this.onFileInputChange}
-                    label={label}
-                    buttonLabel={this.getButtonLabel()}
-                    error={error}
-                    valid={valid}
-                    warning={warning}
-                    small={small}
-                    large={large}
-                    required={required}
-                    disabled={this.getDisabled()}
-                    accept={accept}
-                    multiple={multifile}
-                >
-                    {helpText && <Help>{helpText}</Help>}
-
-                    {error && errorText && <Help error>{errorText}</Help>}
-
-                    <UiCoreFileInput.FileList>
-                        {!value && (
-                            <UiCoreFileInput.Placeholder>
-                                {i18n.t('No file(s) selected yet')}
-                            </UiCoreFileInput.Placeholder>
-                        )}
-
-                        {value &&
-                            value.map(file => (
-                                <UiCoreFileInput.FileListItem
-                                    key={file.name}
-                                    label={file.name}
-                                    onRemove={this.onFileRemove.bind(
-                                        this,
-                                        file
-                                    )}
-                                    removeText={i18n.t('Remove')}
-                                />
-                            ))}
-                    </UiCoreFileInput.FileList>
-                </UiCoreFileInput>
-            </Field>
+            <UiCoreFileInputField
+                className={className}
+                onChange={this.onFileInputChange}
+                label={label}
+                buttonLabel={
+                    buttonLabel || multifile ? btnLabelMulti : btnLabel
+                }
+                error={error}
+                valid={valid}
+                warning={warning}
+                small={small}
+                large={large}
+                required={required}
+                disabled={disabled || (!multifile && value.length >= 1)}
+                accept={accept}
+                multiple={multifile}
+                name={name}
+                helpText={helpText}
+                validationText={validationText}
+                tabIndex={tabIndex}
+                placeholder={placeholder}
+            >
+                {value &&
+                    value.map(file => (
+                        <FileListItem
+                            key={file.name}
+                            label={file.name}
+                            onRemove={this.onFileRemove.bind(this, file)}
+                            removeText={i18n.t('Remove')}
+                        />
+                    ))}
+            </UiCoreFileInputField>
         )
     }
+}
+
+FileInput.defaultProps = {
+    placeholder: i18n.t('No file(s) selected yet'),
 }
 
 FileInput.propTypes = {
@@ -130,6 +117,7 @@ FileInput.propTypes = {
         propTypes.arrayOf(propTypes.instanceOf(File)),
         propTypes.oneOf(['']),
     ]),
+    placeholder: propTypes.string,
 }
 
 const FileInputAdapter = props => (

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 export { Checkbox, CheckboxAdapter } from './components/Checkbox.js'
 export { Form } from './components/Form.js'
 export { Field } from './components/Field.js'
-export { FileInput, FileInputAdapter } from './components/FileInput.js'
+export { FileInput } from './components/FileInput.js'
 export { RadioGroup, RadioGroupAdapter } from './components/RadioGroup.js'
 
 // Mutators

--- a/src/locales/en/translations.json
+++ b/src/locales/en/translations.json
@@ -1,8 +1,8 @@
 {
     "Upload file": "",
     "Upload files": "",
-    "No file(s) selected yet": "",
     "Remove": "",
+    "No file(s) selected yet": "",
     "Required": "",
     "Not a valid e-mail": ""
 }

--- a/stories/FileInput.stories.js
+++ b/stories/FileInput.stories.js
@@ -12,6 +12,7 @@ storiesOf('FileInput', module)
             name="upload"
             label="This is a file upload"
             multifile
+            placeholder=""
         />
     ))
     .add('Required', () => (

--- a/stories/FileInput.stories.js
+++ b/stories/FileInput.stories.js
@@ -1,26 +1,53 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, FileInputAdapter, required } from '../src'
+import { Field, FileInput, required } from '../src'
 import { formDecorator } from './helpers/formDecorator'
+
+const files = [new File([], 'file1.txt'), new File([], 'file2.txt')]
 
 storiesOf('FileInput', module)
     .addDecorator(formDecorator)
     .add('Default', () => (
         <Field
-            component={FileInputAdapter}
+            component={FileInput}
             name="upload"
             label="This is a file upload"
-            multifile
-            placeholder=""
         />
     ))
     .add('Required', () => (
         <Field
-            component={FileInputAdapter}
+            component={FileInput}
             name="upload"
             label="This is a file upload"
             required
             validate={required}
+        />
+    ))
+    .add('Multifile', () => (
+        <Field
+            component={FileInput}
+            name="upload"
+            label="This is a file upload"
+            multifile
+        />
+    ))
+    .add('With values', () => (
+        <Field
+            component={FileInput}
+            name="upload"
+            label="This is a file upload"
+            required
+            multifile
+            initialValue={files}
+            validate={required}
+        />
+    ))
+    .add('Prevent placeholder', () => (
+        <Field
+            component={FileInput}
+            name="upload"
+            label="This is a file upload"
+            placeholder=""
         />
     ))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1121,8 +1121,7 @@
 
 "@dhis2/ui-core@https://github.com/dhis2/ui-core#next":
   version "3.10.0"
-  uid "900d6cb8266b5d1ef66396245ccb34760ae0424f"
-  resolved "https://github.com/dhis2/ui-core#900d6cb8266b5d1ef66396245ccb34760ae0424f"
+  resolved "https://github.com/dhis2/ui-core#56df20c83ee5e32ec4c17b6f6af3e8d31b83cf73"
   dependencies:
     "@dhis2/prop-types" "^1.1.1"
     classnames "^2.2.6"
@@ -9550,10 +9549,15 @@ react-inspector@^3.0.2:
     is-dom "^1.0.9"
     prop-types "^15.6.1"
 
-react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
+react-is@^16.7.0, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
+
+react-is@^16.8.1:
+  version "16.10.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.10.1.tgz#0612786bf19df406502d935494f0450b40b8294f"
+  integrity sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
This is a draft PR, because it relies in ui-core next. Once next has gone into master there, I will update package.json and yarn.lock so you will actually be able to run the storybook out-of-the-box.