### PR TITLE
chore: improve cypress implementation after introduction to project

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,4 @@
 {
-  "baseUrl": "http://localhost:5000",
   "testFiles": "**/*.feature",
   "video": false,
   "projectId": "konyyu"

--- a/cypress/integration/Checkbox/is_selectable.feature
+++ b/cypress/integration/Checkbox/is_selectable.feature
@@ -1,6 +1,6 @@
 Feature: The Checkbox can be selected
 
     Scenario: The user clicks on the Checkbox
-        Given a Checkbox is rendered
+        Given an unchecked Checkbox is rendered
         When the user clicks on the Checkbox
         Then the form value that corresponds to the checkbox will be yes

--- a/cypress/integration/Checkbox/is_selectable/index.js
+++ b/cypress/integration/Checkbox/is_selectable/index.js
@@ -1,7 +1,12 @@
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
-Given('a Checkbox is rendered', () => {
+Given('an unchecked Checkbox is rendered', () => {
     cy.visitStory('Testing:Forms', 'Standard form')
+    // make sure form spy function ran
+    cy.get('.form-spy-inernal')
+    cy.window().then(win => {
+        expect(win.formValues.tnc).to.be.undefined
+    })
 })
 
 When('the user clicks on the Checkbox', () => {

--- a/cypress/support/visitStory.js
+++ b/cypress/support/visitStory.js
@@ -1,6 +1,6 @@
 const urlEncodeStoryBookName = name =>
     name
-        .replace(/\(|\)/g, '')
+        .replace(/\(|\)|:/g, '')
         .replace(/[^a-zA-Z0-9]+/g, '-')
         .toLowerCase()
 

--- a/stories/Form.stories.testing.js
+++ b/stories/Form.stories.testing.js
@@ -19,9 +19,10 @@ import {
     FormSpy,
 } from '../src'
 
+// eslint-disable-next-line react/prop-types
 const valuesToWindow = ({ values }) => {
     window.formValues = values
-    return null
+    return <span className="form-spy-inernal" />
 }
 
 /* eslint-disable react/prop-types */


### PR DESCRIPTION
I've made some small improvements. I think the most important one is to make sure that the checkbox is unchecked before the test checks it (otherwise we might get false positives, if the checking isn't working but the checkbox is checked initially)