### PR TITLE
chore: set version to 0.0.1 because we are not stable and unpublished

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/ui-form",
-    "version": "1.0.4",
+    "version": "0.0.1",
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",
     "sideEffects": false,

--- a/release.config.js
+++ b/release.config.js
@@ -1,6 +1,4 @@
 module.exports = {
     branch: 'master',
-    /* eslint-disable no-template-curly-in-string */
     tagFormat: 'v${version}',
-    /* eslint-enable no-template-curly-in-string */
 }

--- a/src/validators/required.js
+++ b/src/validators/required.js
@@ -1,4 +1,4 @@
 import i18n from '@dhis2/d2-i18n'
 
 export const requiredMessage = i18n.t('Required')
-export const required = value => (!!value ? undefined : requiredMessage)
+export const required = value => (value ? undefined : requiredMessage)


### PR DESCRIPTION
Note: the changes in `release.config.js` and `validators/required.js` were only made to appease the linter.