### PR TITLE
fix: rename required to has-value in all stories and integration tests

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,7 +1,7 @@
 import { configure, addDecorator } from '@storybook/react'
 import { jsxDecorator } from 'storybook-addon-jsx'
 import { withPropsTable } from 'storybook-addon-react-docgen'
-import { CssResetWrapper } from './css-reset-decorator'
+import { CssResetWrapper } from './css-reset-decorator.js'
 
 import 'typeface-roboto'
 

--- a/.storybook/formDecorator.js
+++ b/.storybook/formDecorator.js
@@ -2,7 +2,7 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 import { Button } from '@dhis2/ui-core'
 
-import { Form, FormSpy } from '../src'
+import { Form, FormSpy } from '../src/index.js'
 
 const formProps = {
     onSubmit: values => {

--- a/cypress/integration/Checkbox/Can_toggle_a_boolean/index.js
+++ b/cypress/integration/Checkbox/Can_toggle_a_boolean/index.js
@@ -1,4 +1,4 @@
-import '../common'
+import '../common/index.js'
 import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('an unchecked Checkbox without value is rendered', () => {

--- a/cypress/integration/Checkbox/Can_toggle_a_value/index.js
+++ b/cypress/integration/Checkbox/Can_toggle_a_value/index.js
@@ -1,4 +1,4 @@
-import '../common'
+import '../common/index.js'
 import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('an unchecked Checkbox with a value is rendered', () => {

--- a/cypress/integration/Checkbox/Displays_error/index.js
+++ b/cypress/integration/Checkbox/Displays_error/index.js
@@ -1,4 +1,4 @@
-import '../common'
+import '../common/index.js'
 import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
 import { hasValueMessage } from '../../../../src/validators/hasValue.js'
 

--- a/cypress/integration/Checkbox/Displays_error/index.js
+++ b/cypress/integration/Checkbox/Displays_error/index.js
@@ -1,6 +1,6 @@
 import '../common'
 import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
-import { requiredMessage } from '../../../../src/validators/required'
+import { hasValueMessage } from '../../../../src/validators/hasValue.js'
 
 Given('an unchecked Checkbox is rendered', () => {
     cy.visitStory('Testing:Checkbox', 'Unchecked')
@@ -8,5 +8,5 @@ Given('an unchecked Checkbox is rendered', () => {
 })
 
 Then('an error message is shown', () => {
-    cy.get('.checkbox .error').should('contain', requiredMessage)
+    cy.get('.checkbox .error').should('contain', hasValueMessage)
 })

--- a/cypress/integration/CheckboxGroup/Can_set_a_value/index.js
+++ b/cypress/integration/CheckboxGroup/Can_set_a_value/index.js
@@ -1,4 +1,4 @@
-import '../common'
+import '../common/index.js'
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('the CheckboxGroup has two options', () => {

--- a/cypress/integration/CheckboxGroup/Displays_error/index.js
+++ b/cypress/integration/CheckboxGroup/Displays_error/index.js
@@ -1,7 +1,7 @@
 import '../common'
 import { Then } from 'cypress-cucumber-preprocessor/steps'
-import { requiredMessage } from '../../../../src/validators/required.js'
+import { hasValueMessage } from '../../../../src/validators/hasValue.js'
 
 Then('an error message is shown', () => {
-    cy.get('.error').should('contain', requiredMessage)
+    cy.get('.error').should('contain', hasValueMessage)
 })

--- a/cypress/integration/CheckboxGroup/Displays_error/index.js
+++ b/cypress/integration/CheckboxGroup/Displays_error/index.js
@@ -1,4 +1,4 @@
-import '../common'
+import '../common/index.js'
 import { Then } from 'cypress-cucumber-preprocessor/steps'
 import { hasValueMessage } from '../../../../src/validators/hasValue.js'
 

--- a/cypress/integration/FileInput/Accepts_file/index.js
+++ b/cypress/integration/FileInput/Accepts_file/index.js
@@ -1,4 +1,4 @@
-import '../common'
+import '../common/index.js'
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a multi-file IputField is rendered', () => {

--- a/cypress/integration/FileInput/Displays_error/index.js
+++ b/cypress/integration/FileInput/Displays_error/index.js
@@ -1,4 +1,4 @@
-import '../common'
+import '../common/index.js'
 import { When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 When('a file with the wrong file type is provided', () => {

--- a/cypress/integration/Input/Displays_error/index.js
+++ b/cypress/integration/Input/Displays_error/index.js
@@ -1,5 +1,5 @@
 import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
-import { requiredMessage } from '../../../../src/validators/required.js'
+import { hasValueMessage } from '../../../../src/validators/hasValue.js'
 
 Given('an empty, required Input is rendered', () => {
     cy.visitStory('Testing:Input', 'Required')
@@ -7,5 +7,5 @@ Given('an empty, required Input is rendered', () => {
 })
 
 Then('an error message is shown', () => {
-    cy.get('.error').should('contain', requiredMessage)
+    cy.get('.error').should('contain', hasValueMessage)
 })

--- a/cypress/integration/MultiSelect/Can_set_a_value/index.js
+++ b/cypress/integration/MultiSelect/Can_set_a_value/index.js
@@ -1,4 +1,4 @@
-import '../common'
+import '../common/index.js'
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('the MultiSelect has two options', () => {

--- a/cypress/integration/MultiSelect/Displays_error/index.js
+++ b/cypress/integration/MultiSelect/Displays_error/index.js
@@ -1,7 +1,7 @@
 import '../common'
 import { Then } from 'cypress-cucumber-preprocessor/steps'
-import { requiredMessage } from '../../../../src/validators/required'
+import { hasValueMessage } from '../../../../src/validators/hasValue.js'
 
 Then('an error message is shown', () => {
-    cy.get('.error').should('contain', requiredMessage)
+    cy.get('.error').should('contain', hasValueMessage)
 })

--- a/cypress/integration/MultiSelect/Displays_error/index.js
+++ b/cypress/integration/MultiSelect/Displays_error/index.js
@@ -1,4 +1,4 @@
-import '../common'
+import '../common/index.js'
 import { Then } from 'cypress-cucumber-preprocessor/steps'
 import { hasValueMessage } from '../../../../src/validators/hasValue.js'
 

--- a/cypress/integration/RadioGroup/Can_set_a_value/index.js
+++ b/cypress/integration/RadioGroup/Can_set_a_value/index.js
@@ -1,4 +1,4 @@
-import '../common'
+import '../common/index.js'
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('the RadioGroup has two options', () => {

--- a/cypress/integration/RadioGroup/Displays_error/index.js
+++ b/cypress/integration/RadioGroup/Displays_error/index.js
@@ -1,7 +1,7 @@
 import '../common'
 import { Then } from 'cypress-cucumber-preprocessor/steps'
-import { requiredMessage } from '../../../../src/validators/required'
+import { hasValueMessage } from '../../../../src/validators/hasValue.js'
 
 Then('an error message is shown', () => {
-    cy.get('.error').should('contain', requiredMessage)
+    cy.get('.error').should('contain', hasValueMessage)
 })

--- a/cypress/integration/RadioGroup/Displays_error/index.js
+++ b/cypress/integration/RadioGroup/Displays_error/index.js
@@ -1,4 +1,4 @@
-import '../common'
+import '../common/index.js'
 import { Then } from 'cypress-cucumber-preprocessor/steps'
 import { hasValueMessage } from '../../../../src/validators/hasValue.js'
 

--- a/cypress/integration/SingleSelect/Can_set_a_value/index.js
+++ b/cypress/integration/SingleSelect/Can_set_a_value/index.js
@@ -1,4 +1,4 @@
-import '../common'
+import '../common/index.js'
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('the SingleSelect has one option', () => {

--- a/cypress/integration/SingleSelect/Displays_error/index.js
+++ b/cypress/integration/SingleSelect/Displays_error/index.js
@@ -1,7 +1,7 @@
 import '../common'
 import { Then } from 'cypress-cucumber-preprocessor/steps'
-import { requiredMessage } from '../../../../src/validators/required'
+import { hasValueMessage } from '../../../../src/validators/hasValue.js'
 
 Then('an error message is shown', () => {
-    cy.get('.error').should('contain', requiredMessage)
+    cy.get('.error').should('contain', hasValueMessage)
 })

--- a/cypress/integration/SingleSelect/Displays_error/index.js
+++ b/cypress/integration/SingleSelect/Displays_error/index.js
@@ -1,4 +1,4 @@
-import '../common'
+import '../common/index.js'
 import { Then } from 'cypress-cucumber-preprocessor/steps'
 import { hasValueMessage } from '../../../../src/validators/hasValue.js'
 

--- a/cypress/integration/Switch/Can_toggle_a_boolean/index.js
+++ b/cypress/integration/Switch/Can_toggle_a_boolean/index.js
@@ -1,4 +1,4 @@
-import '../common'
+import '../common/index.js'
 import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('an unchecked Switch without value is rendered', () => {

--- a/cypress/integration/Switch/Can_toggle_a_value/index.js
+++ b/cypress/integration/Switch/Can_toggle_a_value/index.js
@@ -1,4 +1,4 @@
-import '../common'
+import '../common/index.js'
 import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('an unchecked Switch with a value is rendered', () => {

--- a/cypress/integration/Switch/Displays_error/index.js
+++ b/cypress/integration/Switch/Displays_error/index.js
@@ -1,4 +1,4 @@
-import '../common'
+import '../common/index.js'
 import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
 import { hasValueMessage } from '../../../../src/validators/hasValue.js'
 

--- a/cypress/integration/Switch/Displays_error/index.js
+++ b/cypress/integration/Switch/Displays_error/index.js
@@ -1,6 +1,6 @@
 import '../common'
 import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
-import { requiredMessage } from '../../../../src/validators/required'
+import { hasValueMessage } from '../../../../src/validators/hasValue.js'
 
 Given('an unchecked Switch is rendered', () => {
     cy.visitStory('Testing:Switch', 'Unchecked')
@@ -8,5 +8,5 @@ Given('an unchecked Switch is rendered', () => {
 })
 
 Then('an error message is shown', () => {
-    cy.get('.switch .error').should('contain', requiredMessage)
+    cy.get('.switch .error').should('contain', hasValueMessage)
 })

--- a/cypress/integration/TextArea/Displays_error/index.js
+++ b/cypress/integration/TextArea/Displays_error/index.js
@@ -1,5 +1,5 @@
 import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
-import { requiredMessage } from '../../../../src/validators/required'
+import { hasValueMessage } from '../../../../src/validators/hasValue.js'
 
 Given('an empty, required TextArea is rendered', () => {
     cy.visitStory('TextArea', 'Required')
@@ -7,5 +7,5 @@ Given('an empty, required TextArea is rendered', () => {
 })
 
 Then('an error message is shown', () => {
-    cy.get('.error').should('contain', requiredMessage)
+    cy.get('.error').should('contain', hasValueMessage)
 })

--- a/cypress/support/uploadMultipleFiles.js
+++ b/cypress/support/uploadMultipleFiles.js
@@ -1,4 +1,4 @@
-import { hexStringToByte } from './uploadFile/hexStringToByte'
+import { hexStringToByte } from './uploadFile/hexStringToByte.js'
 
 /**
  * @param {Array.<{ fileType: string, fixture: string }>} files

--- a/cypress/support/uploadSingleFile.js
+++ b/cypress/support/uploadSingleFile.js
@@ -1,4 +1,4 @@
-import { hexStringToByte } from './uploadFile/hexStringToByte'
+import { hexStringToByte } from './uploadFile/hexStringToByte.js'
 
 /**
  * @param {string} fileType

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-12-17T14:35:58.462Z\n"
-"PO-Revision-Date: 2019-12-17T14:35:58.462Z\n"
+"POT-Creation-Date: 2020-01-07T15:57:03.910Z\n"
+"PO-Revision-Date: 2020-01-07T15:57:03.910Z\n"
 
 msgid "Upload file"
 msgstr ""
@@ -54,18 +54,6 @@ msgid ""
 "{{patternString}}."
 msgstr ""
 
-msgid "Please provide a valid email address"
-msgstr ""
-
-msgid "Please provide a round number without decimals"
-msgstr ""
-
-msgid "Please provide a valid international phone number."
-msgstr ""
-
-msgid "Please provide a number"
-msgstr ""
-
 msgid "Password should be a string"
 msgstr ""
 
@@ -87,14 +75,26 @@ msgstr ""
 msgid "Password should have at least one special character"
 msgstr ""
 
-msgid "This is a required field"
+msgid "Please provide a username between 1 and 255 characters"
+msgstr ""
+
+msgid "Please provide a valid email address"
+msgstr ""
+
+msgid "Please provide a value"
+msgstr ""
+
+msgid "Please provide a round number without decimals"
+msgstr ""
+
+msgid "Please provide a valid international phone number."
+msgstr ""
+
+msgid "Please provide a number"
 msgstr ""
 
 msgid "Please provide a string"
 msgstr ""
 
 msgid "Please provide a valid url"
-msgstr ""
-
-msgid "Please provide a username between 1 and 255 characters"
 msgstr ""

--- a/src/components/SingleSelect.js
+++ b/src/components/SingleSelect.js
@@ -2,8 +2,8 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 import { SingleSelectField, SingleSelectOption } from '@dhis2/ui-core'
 
-import { normalizeProps } from './shared/helpers'
-import { fieldRenderProps } from './shared/propTypes'
+import { normalizeProps } from './shared/helpers.js'
+import { fieldRenderProps } from './shared/propTypes.js'
 
 const createChangeHandler = props => ({ selected }) =>
     props.input.onChange(selected)

--- a/src/locales/en/translations.json
+++ b/src/locales/en/translations.json
@@ -13,10 +13,6 @@
     "Please enter a number of at least {{lowerBound}}": "",
     "Please enter a number between {{lowerBound}} and {{upperBound}}": "",
     "Please make sure the value of this input matches the pattern {{patternString}}.": "",
-    "Please provide a valid email address": "",
-    "Please provide a round number without decimals": "",
-    "Please provide a valid international phone number.": "",
-    "Please provide a number": "",
     "Password should be a string": "",
     "Password should be at least 8 characters long": "",
     "Password should be no longer than 34 characters": "",
@@ -24,8 +20,12 @@
     "Password should contain at least one UPPERCASE letter": "",
     "Password should contain at least one number": "",
     "Password should have at least one special character": "",
-    "This is a required field": "",
+    "Please provide a username between 1 and 255 characters": "",
+    "Please provide a valid email address": "",
+    "Please provide a value": "",
+    "Please provide a round number without decimals": "",
+    "Please provide a valid international phone number.": "",
+    "Please provide a number": "",
     "Please provide a string": "",
-    "Please provide a valid url": "",
-    "Please provide a username between 1 and 255 characters": ""
+    "Please provide a valid url": ""
 }

--- a/src/validators/__test__/boolean.test.js
+++ b/src/validators/__test__/boolean.test.js
@@ -1,4 +1,4 @@
-import { boolean, invalidBooleanMessage } from '../boolean'
+import { boolean, invalidBooleanMessage } from '../boolean.js'
 import { testValidatorValues, allowsEmptyValues } from './helpers/index.js'
 
 describe('validator: boolean', () => {

--- a/src/validators/__test__/composeValidators.test.js
+++ b/src/validators/__test__/composeValidators.test.js
@@ -1,6 +1,6 @@
-import { composeValidators } from '../composeValidators'
-import { hasValue, hasValueMessage } from '../hasValue'
-import { email, invalidEmailMessage } from '../email'
+import { composeValidators } from '../composeValidators.js'
+import { hasValue, hasValueMessage } from '../hasValue.js'
+import { email, invalidEmailMessage } from '../email.js'
 
 describe('composeValidators', () => {
     const validator = composeValidators(hasValue, email)

--- a/src/validators/__test__/email.test.js
+++ b/src/validators/__test__/email.test.js
@@ -1,4 +1,4 @@
-import { email, invalidEmailMessage } from '../email'
+import { email, invalidEmailMessage } from '../email.js'
 import { testValidatorValues, allowsEmptyValues } from './helpers/index.js'
 
 /*

--- a/src/validators/__test__/internationalPhoneNumber.test.js
+++ b/src/validators/__test__/internationalPhoneNumber.test.js
@@ -1,8 +1,8 @@
 import {
     internationalPhoneNumber,
     invalidInternationalPhoneNumberMessage,
-} from '../internationalPhoneNumber'
-import { testValidatorValues, allowsEmptyValues } from './helpers'
+} from '../internationalPhoneNumber.js'
+import { testValidatorValues, allowsEmptyValues } from './helpers/index.js'
 
 describe('validator: internationalPhoneNumber', () => {
     allowsEmptyValues(internationalPhoneNumber)

--- a/src/validators/createMaxCharacterLength.js
+++ b/src/validators/createMaxCharacterLength.js
@@ -1,5 +1,5 @@
 import i18n from '@dhis2/d2-i18n'
-import { createCharacterLengthRange } from './createCharacterLengthRange'
+import { createCharacterLengthRange } from './createCharacterLengthRange.js'
 
 const createMaxCharacterLength = upperBound =>
     createCharacterLengthRange(

--- a/src/validators/createMaxNumber.js
+++ b/src/validators/createMaxNumber.js
@@ -1,5 +1,5 @@
 import i18n from '@dhis2/d2-i18n'
-import { createNumberRange } from './createNumberRange'
+import { createNumberRange } from './createNumberRange.js'
 
 const createMaxNumber = upperBound =>
     createNumberRange(

--- a/src/validators/createMinCharacterLength.js
+++ b/src/validators/createMinCharacterLength.js
@@ -1,5 +1,5 @@
 import i18n from '@dhis2/d2-i18n'
-import { createCharacterLengthRange } from './createCharacterLengthRange'
+import { createCharacterLengthRange } from './createCharacterLengthRange.js'
 
 const createMinCharacterLength = lowerBound =>
     createCharacterLengthRange(

--- a/src/validators/createMinNumber.js
+++ b/src/validators/createMinNumber.js
@@ -1,5 +1,5 @@
 import i18n from '@dhis2/d2-i18n'
-import { createNumberRange } from './createNumberRange'
+import { createNumberRange } from './createNumberRange.js'
 
 const createMinNumber = lowerBound =>
     createNumberRange(

--- a/stories/Checkbox.stories.js
+++ b/stories/Checkbox.stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, Checkbox, required } from '../src'
+import { Field, Checkbox, hasValue } from '../src'
 import { formDecorator } from '../.storybook/formDecorator'
 
 storiesOf('Checkbox', module)
@@ -14,7 +14,7 @@ storiesOf('Checkbox', module)
             name="agree"
             component={Checkbox}
             required
-            validate={required}
+            validate={hasValue}
             label="Do you agree?"
         />
     ))

--- a/stories/Checkbox.stories.js
+++ b/stories/Checkbox.stories.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, Checkbox, hasValue } from '../src'
-import { formDecorator } from '../.storybook/formDecorator'
+import { Field, Checkbox, hasValue } from '../src/index.js'
+import { formDecorator } from '../.storybook/formDecorator.js'
 
 storiesOf('Checkbox', module)
     .addDecorator(formDecorator)

--- a/stories/Checkbox.stories.testing.js
+++ b/stories/Checkbox.stories.testing.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, Checkbox, hasValue } from '../src'
-import { formDecorator } from '../.storybook/formDecorator'
+import { Field, Checkbox, hasValue } from '../src/index.js'
+import { formDecorator } from '../.storybook/formDecorator.js'
 
 storiesOf('Testing:Checkbox', module)
     .addDecorator(formDecorator)

--- a/stories/Checkbox.stories.testing.js
+++ b/stories/Checkbox.stories.testing.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, Checkbox, required } from '../src'
+import { Field, Checkbox, hasValue } from '../src'
 import { formDecorator } from '../.storybook/formDecorator'
 
 storiesOf('Testing:Checkbox', module)
@@ -12,7 +12,7 @@ storiesOf('Testing:Checkbox', module)
             className="checkbox"
             name="checkbox"
             label="Label text"
-            validate={required}
+            validate={hasValue}
             required
         />
     ))

--- a/stories/CheckboxGroup.stories.js
+++ b/stories/CheckboxGroup.stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, CheckboxGroup, arrayWithIdObjects, required } from '../src'
+import { Field, CheckboxGroup, arrayWithIdObjects, hasValue } from '../src'
 import { formDecorator } from '../.storybook/formDecorator'
 
 const options = [
@@ -28,7 +28,7 @@ storiesOf('CheckboxGroup', module)
             name="choice"
             label="Choose something"
             component={CheckboxGroup}
-            validate={required}
+            validate={hasValue}
             required
             options={options}
             inline={false}

--- a/stories/CheckboxGroup.stories.js
+++ b/stories/CheckboxGroup.stories.js
@@ -1,8 +1,13 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, CheckboxGroup, arrayWithIdObjects, hasValue } from '../src'
-import { formDecorator } from '../.storybook/formDecorator'
+import {
+    Field,
+    CheckboxGroup,
+    arrayWithIdObjects,
+    hasValue,
+} from '../src/index.js'
+import { formDecorator } from '../.storybook/formDecorator.js'
 
 const options = [
     { label: 'Foo', value: 'foo' },

--- a/stories/CheckboxGroup.stories.testing.js
+++ b/stories/CheckboxGroup.stories.testing.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, CheckboxGroup, hasValue } from '../src'
+import { Field, CheckboxGroup, hasValue } from '../src/index.js'
 import { formDecorator } from '../.storybook/formDecorator.js'
 
 const defaultOptions = [

--- a/stories/CheckboxGroup.stories.testing.js
+++ b/stories/CheckboxGroup.stories.testing.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, CheckboxGroup, required } from '../src'
+import { Field, CheckboxGroup, hasValue } from '../src'
 import { formDecorator } from '../.storybook/formDecorator.js'
 
 const defaultOptions = [
@@ -25,7 +25,7 @@ storiesOf('Testing:CheckboxGroup', module)
             name="choice"
             label="Choose something"
             component={CheckboxGroup}
-            validate={required}
+            validate={hasValue}
             required
             options={cypressProps.options || defaultOptions}
             inline={false}

--- a/stories/FileInput.stories.js
+++ b/stories/FileInput.stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, FileInput, required } from '../src'
+import { Field, FileInput, hasValue } from '../src'
 import { formDecorator } from '../.storybook/formDecorator'
 
 const files = [new File([], 'file1.txt'), new File([], 'file2.txt')]
@@ -21,7 +21,7 @@ storiesOf('FileInput', module)
             name="upload"
             label="This is a file upload"
             required
-            validate={required}
+            validate={hasValue}
         />
     ))
     .add('Multifile', () => (
@@ -40,7 +40,7 @@ storiesOf('FileInput', module)
             required
             multifile
             initialValue={files}
-            validate={required}
+            validate={hasValue}
         />
     ))
     .add('Prevent placeholder', () => (

--- a/stories/FileInput.stories.js
+++ b/stories/FileInput.stories.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, FileInput, hasValue } from '../src'
-import { formDecorator } from '../.storybook/formDecorator'
+import { Field, FileInput, hasValue } from '../src/index.js'
+import { formDecorator } from '../.storybook/formDecorator.js'
 
 const files = [new File([], 'file1.txt'), new File([], 'file2.txt')]
 

--- a/stories/Form.stories.testing.js
+++ b/stories/Form.stories.testing.js
@@ -17,7 +17,7 @@ import {
     TextArea,
     composeValidators,
     email,
-    required,
+    hasValue,
 } from '../src/index.js'
 
 const StandardForm = ({ values }) => {
@@ -44,7 +44,7 @@ const StandardForm = ({ values }) => {
                 required
                 label="First name"
                 name="fname"
-                validate={required}
+                validate={hasValue}
                 component={Input}
                 helpText="Please enter your first name, excluding middle names"
             />
@@ -53,7 +53,7 @@ const StandardForm = ({ values }) => {
                 required
                 label="Last name"
                 name="lname"
-                validate={required}
+                validate={hasValue}
                 component={Input}
                 helpText="Please enter your first name, excluding middle names"
             />
@@ -86,7 +86,7 @@ const StandardForm = ({ values }) => {
                     required={values.subscribe}
                     label="E-mail address confirmation"
                     name="email2"
-                    validate={composeValidators(email, required)}
+                    validate={composeValidators(email, hasValue)}
                     component={Input}
                     helpText="Please confirm your e-mail address"
                 />
@@ -178,7 +178,7 @@ const StandardForm = ({ values }) => {
                 required
                 name="tnc"
                 label="I accept the terms and conditions"
-                validate={required}
+                validate={hasValue}
                 component={Checkbox}
                 className="checkbox"
             />

--- a/stories/Input.stories.js
+++ b/stories/Input.stories.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, Input, hasValue } from '../src'
-import { formDecorator } from '../.storybook/formDecorator'
+import { Field, Input, hasValue } from '../src/index.js'
+import { formDecorator } from '../.storybook/formDecorator.js'
 
 storiesOf('Input', module)
     .addDecorator(formDecorator)

--- a/stories/Input.stories.js
+++ b/stories/Input.stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, Input, required } from '../src'
+import { Field, Input, hasValue } from '../src'
 import { formDecorator } from '../.storybook/formDecorator'
 
 storiesOf('Input', module)
@@ -14,7 +14,7 @@ storiesOf('Input', module)
             name="agree"
             component={Input}
             required
-            validate={required}
+            validate={hasValue}
             label="Do you agree?"
         />
     ))

--- a/stories/Input.stories.testing.js
+++ b/stories/Input.stories.testing.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, Input, hasValue } from '../src'
+import { Field, Input, hasValue } from '../src/index.js'
 import { formDecorator } from '../.storybook/formDecorator.js'
 
 storiesOf('Testing:Input', module)

--- a/stories/Input.stories.testing.js
+++ b/stories/Input.stories.testing.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, Input, required } from '../src'
+import { Field, Input, hasValue } from '../src'
 import { formDecorator } from '../.storybook/formDecorator.js'
 
 storiesOf('Testing:Input', module)
@@ -14,7 +14,7 @@ storiesOf('Testing:Input', module)
             name="agree"
             component={Input}
             required
-            validate={required}
+            validate={hasValue}
             label="Do you agree?"
         />
     ))

--- a/stories/MultiSelect.stories.js
+++ b/stories/MultiSelect.stories.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, MultiSelect } from '../src'
-import { formDecorator } from '../.storybook/formDecorator'
+import { Field, MultiSelect } from '../src/index.js'
+import { formDecorator } from '../.storybook/formDecorator.js'
 
 const options = [
     { value: '1', label: 'one' },
@@ -17,7 +17,12 @@ const options = [
     { value: '10', label: 'ten' },
 ]
 
-const initialValue = ['2', '5']
+const initialValue = [
+    { value: '3', label: 'three' },
+    { value: '4', label: 'four' },
+    { value: '9', label: 'nine' },
+    { value: '10', label: 'ten' },
+]
 
 storiesOf('MultiSelect', module)
     .addDecorator(formDecorator)

--- a/stories/MultiSelect.stories.testing.js
+++ b/stories/MultiSelect.stories.testing.js
@@ -1,7 +1,7 @@
 import { Field } from 'react-final-form'
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { MultiSelect, required } from '../src'
+import { MultiSelect, hasValue } from '../src'
 import { formDecorator } from '../.storybook/formDecorator.js'
 
 const defaultOptions = [
@@ -18,7 +18,7 @@ storiesOf('Testing:MultiSelect', module)
             name="multiSelect"
             label="Multi select"
             component={MultiSelect}
-            validate={required}
+            validate={hasValue}
             options={cypressProps.options || defaultOptions}
         />
     ))

--- a/stories/MultiSelect.stories.testing.js
+++ b/stories/MultiSelect.stories.testing.js
@@ -1,7 +1,7 @@
 import { Field } from 'react-final-form'
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { MultiSelect, hasValue } from '../src'
+import { MultiSelect, hasValue } from '../src/index.js'
 import { formDecorator } from '../.storybook/formDecorator.js'
 
 const defaultOptions = [

--- a/stories/RadioGroup.stories.js
+++ b/stories/RadioGroup.stories.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, RadioGroup, hasValue } from '../src'
-import { formDecorator } from '../.storybook/formDecorator'
+import { Field, RadioGroup, hasValue } from '../src/index.js'
+import { formDecorator } from '../.storybook/formDecorator.js'
 
 const options = [
     { label: 'Foo', value: 'foo' },

--- a/stories/RadioGroup.stories.js
+++ b/stories/RadioGroup.stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, RadioGroup, required } from '../src'
+import { Field, RadioGroup, hasValue } from '../src'
 import { formDecorator } from '../.storybook/formDecorator'
 
 const options = [
@@ -26,7 +26,7 @@ storiesOf('RadioGroup', module)
             name="choice"
             label="Choose something"
             component={RadioGroup}
-            validate={required}
+            validate={hasValue}
             required
             options={options}
         />

--- a/stories/RadioGroup.stories.testing.js
+++ b/stories/RadioGroup.stories.testing.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, RadioGroup, required } from '../src'
+import { Field, RadioGroup, hasValue } from '../src'
 import { formDecorator } from '../.storybook/formDecorator'
 
 const defaultOptions = [
@@ -25,7 +25,7 @@ storiesOf('Testing:RadioGroup', module)
             name="choice"
             label="Choose something"
             component={RadioGroup}
-            validate={required}
+            validate={hasValue}
             required
             options={cypressProps.options || defaultOptions}
         />

--- a/stories/RadioGroup.stories.testing.js
+++ b/stories/RadioGroup.stories.testing.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, RadioGroup, hasValue } from '../src'
-import { formDecorator } from '../.storybook/formDecorator'
+import { Field, RadioGroup, hasValue } from '../src/index.js'
+import { formDecorator } from '../.storybook/formDecorator.js'
 
 const defaultOptions = [
     { label: 'Foo', value: 'foo' },

--- a/stories/SingleSelect.stories.js
+++ b/stories/SingleSelect.stories.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, SingleSelect } from '../src'
-import { formDecorator } from '../.storybook/formDecorator'
+import { Field, SingleSelect } from '../src/index.js'
+import { formDecorator } from '../.storybook/formDecorator.js'
 
 const options = [
     { value: '1', label: 'one' },
@@ -16,6 +16,8 @@ const options = [
     { value: '9', label: 'nine' },
     { value: '10', label: 'ten' },
 ]
+
+const initialValue = { value: '4', label: 'four' }
 
 storiesOf('SingleSelect', module)
     .addDecorator(formDecorator)
@@ -33,6 +35,6 @@ storiesOf('SingleSelect', module)
             name="agree"
             label="Do you agree?"
             options={options}
-            initialValue="1"
+            initialValue={initialValue}
         />
     ))

--- a/stories/SingleSelect.stories.testing.js
+++ b/stories/SingleSelect.stories.testing.js
@@ -1,7 +1,7 @@
 import { Field } from 'react-final-form'
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { SingleSelect, hasValue } from '../src'
+import { SingleSelect, hasValue } from '../src/index.js'
 import { formDecorator } from '../.storybook/formDecorator.js'
 
 const defaultOptions = [{ value: 'initial', label: 'Initial' }]

--- a/stories/SingleSelect.stories.testing.js
+++ b/stories/SingleSelect.stories.testing.js
@@ -1,7 +1,7 @@
 import { Field } from 'react-final-form'
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { SingleSelect, required } from '../src'
+import { SingleSelect, hasValue } from '../src'
 import { formDecorator } from '../.storybook/formDecorator.js'
 
 const defaultOptions = [{ value: 'initial', label: 'Initial' }]
@@ -15,7 +15,7 @@ storiesOf('Testing:SingleSelect', module)
             name="singleSelect"
             label="Single select"
             component={SingleSelect}
-            validate={required}
+            validate={hasValue}
             options={cypressProps.options || defaultOptions}
         />
     ))

--- a/stories/Switch.stories.js
+++ b/stories/Switch.stories.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, Switch, hasValue } from '../src'
-import { formDecorator } from '../.storybook/formDecorator'
+import { Field, Switch, hasValue } from '../src/index.js'
+import { formDecorator } from '../.storybook/formDecorator.js'
 
 storiesOf('Switch', module)
     .addDecorator(formDecorator)

--- a/stories/Switch.stories.js
+++ b/stories/Switch.stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, Switch, required } from '../src'
+import { Field, Switch, hasValue } from '../src'
 import { formDecorator } from '../.storybook/formDecorator'
 
 storiesOf('Switch', module)
@@ -14,7 +14,7 @@ storiesOf('Switch', module)
             name="agree"
             component={Switch}
             required
-            validate={required}
+            validate={hasValue}
             label="Do you agree?"
         />
     ))

--- a/stories/Switch.stories.testing.js
+++ b/stories/Switch.stories.testing.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, Switch, required } from '../src'
+import { Field, Switch, hasValue } from '../src'
 import { formDecorator } from '../.storybook/formDecorator'
 
 storiesOf('Testing:Switch', module)
@@ -12,7 +12,7 @@ storiesOf('Testing:Switch', module)
             className="switch"
             name="switch"
             label="Label text"
-            validate={required}
+            validate={hasValue}
             required
         />
     ))

--- a/stories/Switch.stories.testing.js
+++ b/stories/Switch.stories.testing.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, Switch, hasValue } from '../src'
-import { formDecorator } from '../.storybook/formDecorator'
+import { Field, Switch, hasValue } from '../src/index.js'
+import { formDecorator } from '../.storybook/formDecorator.js'
 
 storiesOf('Testing:Switch', module)
     .addDecorator(formDecorator)

--- a/stories/TextArea.stories.js
+++ b/stories/TextArea.stories.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, TextArea, hasValue } from '../src'
-import { formDecorator } from '../.storybook/formDecorator'
+import { Field, TextArea, hasValue } from '../src/index.js'
+import { formDecorator } from '../.storybook/formDecorator.js'
 
 storiesOf('TextArea', module)
     .addDecorator(formDecorator)

--- a/stories/TextArea.stories.js
+++ b/stories/TextArea.stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, TextArea, required } from '../src'
+import { Field, TextArea, hasValue } from '../src'
 import { formDecorator } from '../.storybook/formDecorator'
 
 storiesOf('TextArea', module)
@@ -22,7 +22,7 @@ storiesOf('TextArea', module)
             name="agree"
             component={TextArea}
             required
-            validate={required}
+            validate={hasValue}
             label="Do you agree?"
         />
     ))

--- a/stories/TextArea.stories.testing.js
+++ b/stories/TextArea.stories.testing.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, TextArea, hasValue } from '../src'
+import { Field, TextArea, hasValue } from '../src/index.js'
 import { formDecorator } from '../.storybook/formDecorator.js'
 
 storiesOf('TextArea', module)

--- a/stories/TextArea.stories.testing.js
+++ b/stories/TextArea.stories.testing.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Field, TextArea, required } from '../src'
+import { Field, TextArea, hasValue } from '../src'
 import { formDecorator } from '../.storybook/formDecorator.js'
 
 storiesOf('TextArea', module)
@@ -18,7 +18,7 @@ storiesOf('TextArea', module)
             required
             name="comment"
             component={TextArea}
-            validate={required}
+            validate={hasValue}
             label="Do you have any comments?"
         />
     ))


### PR DESCRIPTION
When I renamed the `required` validator to `hasValue`, I completely forgot to check the stories and e2e tests. Everything was broken.... But no longer...

FYI: for this repo, we need to enable e2e tests in the travis build (or as a GitHub action). But we also need to setup a release procedure etc. I will pick up those things together in a separate PR.