### PR TITLE
fix: make all components return an empty string when empty

### DIFF
--- a/cypress/integration/Checkbox/Can_toggle_a_boolean.feature
+++ b/cypress/integration/Checkbox/Can_toggle_a_boolean.feature
@@ -8,4 +8,4 @@ Feature: The Checkbox can toggle a boolean
     Scenario: The user unchecks the Checkbox
         Given a checked Checkbox without value is rendered
         When the user clicks on the Checkbox
-        Then the form value that corresponds to the checkbox will be false
+        Then the form value that corresponds to the checkbox will be null

--- a/cypress/integration/Checkbox/Can_toggle_a_boolean/index.js
+++ b/cypress/integration/Checkbox/Can_toggle_a_boolean/index.js
@@ -15,6 +15,6 @@ Given('a checked Checkbox without value is rendered', () => {
     cy.verifyFormValue('checkbox', true)
 })
 
-Then('the form value that corresponds to the checkbox will be false', () => {
-    cy.verifyFormValue('checkbox', false)
+Then('the form value that corresponds to the checkbox will be null', () => {
+    cy.verifyFormValue('checkbox', null)
 })

--- a/cypress/integration/Switch/Can_toggle_a_boolean.feature
+++ b/cypress/integration/Switch/Can_toggle_a_boolean.feature
@@ -8,4 +8,4 @@ Feature: The Switch can toggle a value
     Scenario: The user disables the Switch
         Given a checked Switch without value is rendered
         When the user clicks on the Switch
-        Then the form value that corresponds to the switch will be false
+        Then the form value that corresponds to the switch will be null

--- a/cypress/integration/Switch/Can_toggle_a_boolean/index.js
+++ b/cypress/integration/Switch/Can_toggle_a_boolean/index.js
@@ -15,6 +15,6 @@ Given('a checked Switch without value is rendered', () => {
     cy.verifyFormValue('switch', true)
 })
 
-Then('the form value that corresponds to the switch will be false', () => {
-    cy.verifyFormValue('switch', false)
+Then('the form value that corresponds to the switch will be null', () => {
+    cy.verifyFormValue('switch', null)
 })

--- a/src/components/MultiSelect.js
+++ b/src/components/MultiSelect.js
@@ -3,7 +3,6 @@ import propTypes from '@dhis2/prop-types'
 import { MultiSelectField, MultiSelectOption } from '@dhis2/ui-core'
 
 import {
-    createSelectChangeHandler,
     createFocusHandler,
     createBlurHandler,
     hasError,
@@ -12,6 +11,11 @@ import {
     getValidationText,
 } from './shared/helpers.js'
 import { inputPropType, metaPropType } from './shared/propTypes.js'
+
+const createSelectChangeHandler = ({ onChange }) => ({ selected }) => {
+    const value = Array.isArray(selected) && selected.length > 0 ? selected : ''
+    onChange(value)
+}
 
 const MultiSelect = ({
     error,

--- a/src/components/SingleSelect.js
+++ b/src/components/SingleSelect.js
@@ -3,7 +3,6 @@ import propTypes from '@dhis2/prop-types'
 import { SingleSelectField, SingleSelectOption } from '@dhis2/ui-core'
 
 import {
-    createSelectChangeHandler,
     createFocusHandler,
     createBlurHandler,
     hasError,
@@ -12,6 +11,11 @@ import {
     getValidationText,
 } from './shared/helpers.js'
 import { inputPropType, metaPropType } from './shared/propTypes.js'
+
+const createSelectChangeHandler = ({ onChange }) => ({ selected }) => {
+    const value = 'value' in selected && 'label' in selected ? selected : ''
+    onChange(value)
+}
 
 const SingleSelect = ({
     error,
@@ -38,7 +42,7 @@ const SingleSelect = ({
             onFocus={createFocusHandler(input, onFocus)}
             onChange={createSelectChangeHandler(input)}
             onBlur={createBlurHandler(input, onBlur)}
-            selected={input.value || []}
+            selected={input.value || {}}
         >
             {options.map(option => (
                 <SingleSelectOption key={option.value} {...option} />

--- a/src/components/shared/helpers.js
+++ b/src/components/shared/helpers.js
@@ -1,7 +1,6 @@
 export { createBlurHandler } from './helpers/createBlurHandler.js'
 export { createChangeHandler } from './helpers/createChangeHandler.js'
 export { createFocusHandler } from './helpers/createFocusHandler.js'
-export { createSelectChangeHandler } from './helpers/createSelectChangeHandler.js'
 export { createToggleChangeHandler } from './helpers/createToggleChangeHandler.js'
 export { getValidationText } from './helpers/getValidationText.js'
 export { hasError } from './helpers/hasError.js'

--- a/src/components/shared/helpers/createSelectChangeHandler.js
+++ b/src/components/shared/helpers/createSelectChangeHandler.js
@@ -1,4 +1,0 @@
-const createSelectChangeHandler = ({ onChange }) => ({ selected }) => {
-    onChange(selected)
-}
-export { createSelectChangeHandler }

--- a/src/components/shared/helpers/createToggleChangeHandler.js
+++ b/src/components/shared/helpers/createToggleChangeHandler.js
@@ -1,13 +1,7 @@
-// If the input has a value (checkedValue prop) the form value is: checkedValue || null
-// Otherwise the form-value is: true || false
-const getToggleValue = ({ checked, value }) => {
-    if (value) {
-        return checked ? value : null
-    }
-    return checked
-}
-
-const createToggleChangeHandler = input => payload =>
-    input.onChange(getToggleValue(payload))
+// If the input is checked and has a value (checkedValue prop) that is used as the form value
+// A checked input without a value produces true
+// And an unchecked input always produces null
+const createToggleChangeHandler = input => ({ checked, value }) =>
+    input.onChange(checked ? value || true : null)
 
 export { createToggleChangeHandler }

--- a/src/components/shared/helpers/createToggleChangeHandler.js
+++ b/src/components/shared/helpers/createToggleChangeHandler.js
@@ -1,7 +1,7 @@
 // If the input is checked and has a value (checkedValue prop) that is used as the form value
 // A checked input without a value produces true
-// And an unchecked input always produces null
+// And an unchecked input always produces an empty string
 const createToggleChangeHandler = input => ({ checked, value }) =>
-    input.onChange(checked ? value || true : null)
+    input.onChange(checked ? value || true : '')
 
 export { createToggleChangeHandler }

--- a/stories/SingleSelect.stories.js
+++ b/stories/SingleSelect.stories.js
@@ -27,6 +27,8 @@ storiesOf('SingleSelect', module)
             name="agree"
             label="Do you agree?"
             options={options}
+            clearable
+            clearText="Clear"
         />
     ))
     .add('InitialValue', () => (


### PR DESCRIPTION
## UPDATE:
I've updated the issue title, and scope based on extensive discussions with @ismay. The text below doesn't really describe what this PR is about very accurately at all anymore. I think this comment provides the best summary for the current state of this PR: https://github.com/dhis2/ui-forms/pull/205#issuecomment-574246239

### Previous behaviour

|  | Has `value` attribute on `<input />` | No `value` attribute on `<input />`  |
| ------------- | ------------- |------------- |
| `checked` is `true`  | Text from `value` attribute | `true`  |
| `checked` is `false`  | `null`  | **`false`**  |

### Current behaviour

|  | Has `value` attribute on `<input />` | No `value` attribute on `<input />`  |
| ------------- | ------------- |------------- |
| `checked` is `true`  | Text from `value` attribute | `true`  |
| `checked` is `false`  | `null`  | **`null`** (changed) |

### Motivation
1. The main problem is that the previous behaviour created a fundamental difference between:
    1. An unchecked checkbox that hadn't been touched (no form value)
    2. A checkbox which was first checked by the user, and then unchecked again (`false`)

    I think both scenarios should produce identical results.
2. It's more consistent to have the same deselected form value regardless if the input has a value attribute.
3. This is better aligned with our working definition of an empty field (`''` || `null` || `undefined`). For example, the `hasValue` validator will now still produce an error for the scenario in 1.i